### PR TITLE
fix : 채팅방 목록 조회 쿼리 수정

### DIFF
--- a/src/main/java/org/example/server/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/org/example/server/chatroom/repository/ChatRoomRepository.java
@@ -15,7 +15,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query("SELECT cr.chatRoomId, cr.title, cr.isFavorited " +
             "FROM ChatRoom cr " +
-            "WHERE cr.user.userId = :userId")
+            "WHERE cr.user.userId = :userId " +
+            "ORDER BY cr.updateAt DESC")
     List<ChatRoomResponse.GetChatRoomResponse> findByUserId(@Param("userId") Long userId);
 
     boolean existsByUser_UserIdAndChatRoomId(Long userId, Long chatRoomId);
@@ -25,5 +26,4 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "WHERE cr.user.userId = :userId AND cr.chatRoomId = :chatRoomId")
     Optional<ChatRoom> findByUserIdAndChatRoomId(@Param("userId") Long userId,
                                                 @Param("chatRoomId") Long chatRoomId);
-
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#37

## 📝작업 내용
채팅방 목록 조회 쿼리에 업데이트순으로 정렬하도록 수정했습니다.

### 스크린샷 (선택)
<img width="679" height="120" alt="스크린샷 2025-11-04 22 08 05" src="https://github.com/user-attachments/assets/da5572e1-4536-41af-9d2b-af9cf24c5c53" />

## 💬리뷰 요구사항(선택)
