### PR TITLE
chatRoom 생성 테스트용 userId 1고정 해제

### DIFF
--- a/src/main/java/org/example/server/chatroom/FixedAuthenticatedUserProvider.java
+++ b/src/main/java/org/example/server/chatroom/FixedAuthenticatedUserProvider.java
@@ -1,20 +1,31 @@
 package org.example.server.chatroom;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.example.server.social.dto.CustomOAuth2User;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 @Component
 public class FixedAuthenticatedUserProvider implements AuthenticatedUserProvider {
 
-    private final Long defaultUserId;
-
-    public FixedAuthenticatedUserProvider(@Value("${chat.default-user-id:1}") Long defaultUserId) {
-        this.defaultUserId = defaultUserId;
-    }
-
     @Override
     public Mono<Long> getCurrentUserId() {
-        return Mono.just(defaultUserId);
+        return Mono.defer(() -> {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (authentication != null
+                    && authentication.isAuthenticated()
+                    && !(authentication instanceof AnonymousAuthenticationToken)) {
+                Object principal = authentication.getPrincipal();
+
+                if (principal instanceof CustomOAuth2User customUser) {
+                    return Mono.just(customUser.getUserId());
+                }
+            }
+
+            return Mono.error(new IllegalStateException("인증된 사용자 정보를 찾을 수 없습니다."));
+        });
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #33
## 📝작업 내용
chatRoom테스트용 userId 1고정 해제
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="1469" height="651" alt="image" src="https://github.com/user-attachments/assets/8795128f-f89f-4050-824e-aa4f2344f99d" />

<img width="1452" height="617" alt="image" src="https://github.com/user-attachments/assets/b5f2358b-37ce-4511-b7af-9b52307186ce" />

## 💬리뷰 요구사항(선택)
